### PR TITLE
Add auto-synthesized Hashable to Key, Accidental and KeyType structs

### DIFF
--- a/Source/Accidental.swift
+++ b/Source/Accidental.swift
@@ -100,7 +100,7 @@ public func ===(lhs: Accidental, rhs: Accidental) -> Bool {
 }
 
 /// The enum used for calculating values of the `Key`s and `Pitche`s.
-public enum Accidental: Codable, Equatable, RawRepresentable, ExpressibleByIntegerLiteral, CustomStringConvertible {
+public enum Accidental: Codable, Equatable, Hashable, RawRepresentable, ExpressibleByIntegerLiteral, CustomStringConvertible {
   /// No accidental.
   case natural
   /// Reduces the `Key` or `Pitch` value amount of halfsteps.

--- a/Source/Key.swift
+++ b/Source/Key.swift
@@ -21,10 +21,10 @@ public func ==(lhs: Key, rhs: Key) -> Bool {
 }
 
 /// Represents the keys that notes and pitches are based on.
-public struct Key: Codable, Equatable, CustomStringConvertible {
+public struct Key: Codable, Equatable, Hashable, CustomStringConvertible {
 
   /// Base pitch of the key without accidentals. Accidentals will take account in the parent struct, `Key`. Integer values are based on C = 0 on western chromatic scale.
-  public enum KeyType: Int, Codable, Equatable, CustomStringConvertible {
+  public enum KeyType: Int, Codable, Equatable, Hashable, CustomStringConvertible {
     /// C key.
     case c = 0
     /// D key.


### PR DESCRIPTION
We don't need to implement Equatable or Hashable protocols.

https://github.com/apple/swift-evolution/blob/master/proposals/0185-synthesize-equatable-hashable.md