### PR TITLE
Change ScaleType and ChordProgression from enum to struct to realize …

### DIFF
--- a/Source/ChordProgression.swift
+++ b/Source/ChordProgression.swift
@@ -73,99 +73,51 @@ public enum ChordProgressionNode: Int, CustomStringConvertible, Codable {
 }
 
 /// Chord progression enum that you can create hard-coded and custom progressions.
-public enum ChordProgression: CustomStringConvertible, Codable {
+public struct ChordProgression: CustomStringConvertible, Codable, Equatable {
   /// All nodes from first to seventh.
-  case allNodes
+  static let allNodes = ChordProgression(nodes: [.i, .ii, .iii, .iv, .v, .vi, .vii])
   /// I - V - VI - IV progression.
-  case i_v_vi_iv
+  static let i_v_vi_iv = ChordProgression(nodes: [.i, .v, .vi, .iv])
   /// VI - V - IV - V progression.
-  case vi_v_iv_v
+  static let vi_v_iv_v = ChordProgression(nodes: [.vi, .v, .iv, .v])
   /// I - VI - IV - V progression.
-  case i_vi_iv_v
+  static let i_vi_iv_v = ChordProgression(nodes: [.i, .vi, .iv, .v])
   /// I - IV - VI - V progression.
-  case i_iv_vi_v
+  static let i_iv_vi_v = ChordProgression(nodes: [.i, .iv, .vi, .v])
   /// I - V - IV - V progression.
-  case i_v_iv_v
+  static let i_v_iv_v = ChordProgression(nodes: [.i, .v, .iv, .v])
   /// VI - II - V - I progression.
-  case vi_ii_v_i
+  static let vi_ii_v_i = ChordProgression(nodes: [.vi, .ii, .v, .i])
   /// I - VI - II - V progression.
-  case i_vi_ii_v
+  static let i_vi_ii_v = ChordProgression(nodes: [.i, .vi, .ii, .v])
   /// I - IV - II - V progression.
-  case i_iv_ii_v
+  static let i_iv_ii_v = ChordProgression(nodes: [.i, .iv, .ii, .v])
   /// VI - IV - I - V progression.
-  case vi_iv_i_v
+  static let vi_iv_i_v = ChordProgression(nodes: [.vi, .iv, .i, .v])
   /// I - VI - III - VII progression.
-  case i_vi_iii_vii
+  static let i_vi_iii_vii = ChordProgression(nodes: [.i, .vi, .iii, .vii])
   /// VI - V - IV - III progression.
-  case vi_v_iv_iii
+  static let vi_v_iv_iii = ChordProgression(nodes: [.vi, .v, .iv, .iii])
   /// I - V - VI - III - IV - I - IV - V progression.
-  case i_v_vi_iii_iv_i_iv_v
+  static let i_v_vi_iii_iv_i_iv_v = ChordProgression(nodes: [.i, .v, .vi, .iii, .iv, .i, .iv, .v])
   /// IV - I - V - IV progression.
-  case iv_i_v_iv
+  static let iv_i_v_iv = ChordProgression(nodes: [.iv, .i, .v, .iv])
   /// I - II - VI - IV progression.
-  case i_ii_vi_iv
+  static let i_ii_vi_iv = ChordProgression(nodes: [.i, .ii, .vi, .iv])
   /// I - III - VI - IV progression.
-  case i_iii_vi_iv
+  static let i_iii_vi_iv = ChordProgression(nodes: [.i, .iii, .vi, .iv])
   /// I - V - II - IV progression.
-  case i_v_ii_iv
+  static let i_v_ii_iv = ChordProgression(nodes: [.i, .v, .ii, .iv])
   /// II - IV - I - V progression.
-  case ii_iv_i_v﻿
-  /// Custom progression with any node sequence.
-  case custom([ChordProgressionNode])
+  static let ii_iv_i_v = ChordProgression(nodes: [.ii, .iv, .i, .v])
+
+  let nodes: [ChordProgressionNode]
 
   /// Initilizes the chord progression with its nodes.
   ///
   /// - Parameter nodes: Nodes of the chord progression.
   public init(nodes: [ChordProgressionNode]) {
-    if let progression = ChordProgression.all.filter({ $0.nodes == nodes }).first {
-      self = progression
-    } else {
-      self = .custom(nodes)
-    }
-  }
-
-  /// Returns all nodes of the progression.
-  public var nodes: [ChordProgressionNode] {
-    switch self {
-    case .allNodes:
-      return [.i, .ii, .iii, .iv, .v, .vi, .vii]
-    case .i_v_vi_iv:
-      return [.i, .v, .vi, .iv]
-    case .vi_v_iv_v:
-      return [.vi, .v, .iv, .v]
-    case .i_vi_iv_v:
-      return [.i, .vi, .iv, .v]
-    case .i_iv_vi_v:
-      return [.i, .iv, .vi, .v]
-    case .i_v_iv_v:
-      return [.i, .v, .iv, .v]
-    case .vi_ii_v_i:
-      return [.v, .ii, .v, .i]
-    case .i_vi_ii_v:
-      return [.i, .vi, .ii, .v]
-    case .i_iv_ii_v:
-      return [.i, .iv, .ii, .v]
-    case .vi_iv_i_v:
-      return [.vi, .iv, .i, .v]
-    case .i_vi_iii_vii:
-      return [.i, .vi, .iii, .vii]
-    case .vi_v_iv_iii:
-      return [.vi, .v, .vi, .iii]
-    case .i_v_vi_iii_iv_i_iv_v:
-      return [.i, .v, .vi, .iii, .iv, .i, .iv, .v]
-    case .iv_i_v_iv:
-      return [.iv, .i, .v, .iv]
-    case .i_ii_vi_iv:
-      return [.i, .ii, .vi, .iv]
-    case .i_iii_vi_iv:
-      return [.i, .iii, .vi, .iv]
-    case .i_v_ii_iv:
-      return [.i, .v, .ii, .iv]
-    case .ii_iv_i_v﻿:
-      return [.ii, .iv, .i, .v]
-    case let .custom(nodes):
-      return nodes
-    }
+    self.nodes = nodes
   }
 
   /// All hard-coded chord progressions.
@@ -188,7 +140,7 @@ public enum ChordProgression: CustomStringConvertible, Codable {
       .i_ii_vi_iv,
       .i_iii_vi_iv,
       .i_v_ii_iv,
-      .ii_iv_i_v﻿,
+      .ii_iv_i_v,
     ]
   }
 
@@ -215,7 +167,7 @@ public enum ChordProgression: CustomStringConvertible, Codable {
 
   /// Returns the chord progression name.
   public var description: String {
-    if case .allNodes = self {
+    if self == ChordProgression.allNodes {
       return "All"
     }
     return nodes.map({ "\($0)" }).joined(separator: " - ")
@@ -247,5 +199,11 @@ public enum ChordProgression: CustomStringConvertible, Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(nodes, forKey: .nodes)
+  }
+
+  // MARK: Equatable
+
+  public static func == (lhs: ChordProgression, rhs: ChordProgression) -> Bool {
+    return lhs.nodes == rhs.nodes
   }
 }

--- a/Source/Scale.swift
+++ b/Source/Scale.swift
@@ -12,180 +12,114 @@ import Foundation
 
 // MARK: - ScaleType
 
-/// Checks the equability between two `ScaleType`s by their intervals.
-///
-/// - Parameters:
-///   - left: Left handside of the equation.
-///   - right: Right handside of the equation.
-/// - Returns: Returns Bool value of equation of two given scale types.
-public func == (left: ScaleType, right: ScaleType) -> Bool {
-  return left.intervals == right.intervals
-}
-
 /// Represents scale by the intervals between note sequences.
-public enum ScaleType: Equatable {
+public struct ScaleType: Equatable {
   /// Major scale.
-  case major
+  public static let major = ScaleType(intervals: ScaleType.ionian.intervals, description: "Major")
   /// Minor scale.
-  case minor
+  public static let minor = ScaleType(intervals: ScaleType.aeolian.intervals, description: "Minor")
   /// Harmonic minor scale.
-  case harmonicMinor
+  public static let harmonicMinor = ScaleType(intervals: [.P1, .M2, .m3, .P4, .P5, .m6, .M7], description: "Harmonic Minor")
   /// Melodic minor scale.
-  case melodicMinor
+  public static let melodicMinor = ScaleType(intervals: [.P1, .M2, .m3, .P4, .P5, .M6, .m7], description: "Melodic Minor")
   /// Pentatonic major scale.
-  case pentatonicMajor
+  public static let pentatonicMajor = ScaleType(intervals: [.P1, .M2, .M3, .P5, .M6], description: "Pentatonic Major")
   /// Pentatonic minor scale.
-  case pentatonicMinor
+  public static let pentatonicMinor = ScaleType(intervals: [.P1, .m3, .P4, .P5, .m7], description: "Pentatonic Minor")
   /// Pentatonic blues scale.
-  case pentatonicBlues
+  public static let pentatonicBlues = ScaleType(intervals: [.P1, .m3, .P4, .d5, .P5, .m7], description: "Pentatonic Blues")
   /// Pentatonic neutral scale.
-  case pentatonicNeutral
+  public static let pentatonicNeutral = ScaleType(intervals: [.P1, .M2, .P4, .P5, .m7], description: "Pentatonic Neutral")
   /// Ionian scale.
-  case ionian
+  public static let ionian = ScaleType(intervals: [.P1, .M2, .M3, .P4, .P5, .M6, .M7], description: "Ionian")
   /// Aeolian scale.
-  case aeolian
+  public static let aeolian = ScaleType(intervals: [.P1, .M2, .m3, .P4, .P5, .m6, .m7], description: "Aeolian")
   /// Dorian scale.
-  case dorian
+  public static let dorian = ScaleType(intervals: [.P1, .M2, .m3, .P4, .P5, .M6, .m7], description: "Dorian")
   /// Mixolydian scale.
-  case mixolydian
+  public static let mixolydian = ScaleType(intervals: [.P1, .M2, .M3, .P4, .P5, .M6, .m7], description: "Mixolydian")
   /// Phrygian scale.
-  case phrygian
+  public static let phrygian = ScaleType(intervals: [.P1, .m2, .m3, .P4, .P5, .m6, .m7], description: "Phrygian")
   /// Lydian scale.
-  case lydian
+  public static let lydian = ScaleType(intervals: [.P1, .M2, .M3, .d5, .P5, .M6, .M7], description: "Lydian")
   /// Locrian scale.
-  case locrian
+  public static let locrian = ScaleType(intervals: [.P1, .m2, .m3, .P4, .d5, .m6, .m7], description: "Locrian")
   /// Half diminished scale.
-  case dimHalf
+  public static let dimHalf = ScaleType(intervals: [.P1, .m2, .m3, .M3, .d5, .P5, .M6, .m7], description: "Half Diminished")
   /// Whole diminished scale.
-  case dimWhole
+  public static let dimWhole = ScaleType(intervals: [.P1, .M2, .m3, .P4, .d5, .m6, .M6, .M7], description: "Whole Diminished")
   /// Whole scale.
-  case whole
+  public static let whole = ScaleType(intervals: [.P1, .M2, .M3, .d5, .m6, .m7], description: "Whole")
   /// Augmented scale.
-  case augmented
+  public static let augmented = ScaleType(intervals: [.m3, .M3, .P5, .m6, .M7], description: "Augmented")
   /// Chromatic scale.
-  case chromatic
+  public static let chromatic = ScaleType(intervals: [.P1, .m2, .M2, .m3, .M3, .P4, .d5, .P5, .m6, .M6, .m7, .M7], description: "Chromatic")
   /// Roumanian minor scale.
-  case roumanianMinor
+  public static let romanianMinor = ScaleType(intervals: [.P1, .M2, .m3, .d5, .P5, .M6, .m7], description: "Romanian Minor")
   /// Spanish gypsy scale.
-  case spanishGypsy
+  public static let spanishGypsy = ScaleType(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .m7], description: "Spanish Gypsy")
   /// Blues scale.
-  case blues
+  public static let blues = ScaleType(intervals: [.P1, .m3, .P4, .d5, .P5, .m7], description: "Blues")
   /// Diatonic scale.
-  case diatonic
+  public static let diatonic = ScaleType(intervals: [.P1, .M2, .M3, .P5, .M6], description: "Diatonic")
   /// Dobule harmonic scale.
-  case doubleHarmonic
+  public static let doubleHarmonic = ScaleType(intervals: [.P1, .m2, .M3, .P4, .P5, .m6, .M7], description: "Double Harmonic")
   /// Eight tone spanish scale.
-  case eightToneSpanish
+  public static let eightToneSpanish = ScaleType(intervals: [.P1, .m2, .m3, .M3, .P4, .d5, .m6, .m7], description: "Eight Tone Spanish")
   /// Enigmatic scale.
-  case enigmatic
+  public static let enigmatic = ScaleType(intervals: [.P1, .m2, .M3, .d5, .m6, .m7, .M7], description: "Enigmatic")
   /// Leading whole tone scale.
-  case leadingWholeTone
+  public static let leadingWholeTone = ScaleType(intervals: [.P1, .M2, .M3, .d5, .m6, .M6, .m7], description: "Leading Whole Tone")
   /// Lydian augmented scale.
-  case lydianAugmented
+  public static let lydianAugmented = ScaleType(intervals: [.P1, .M2, .M3, .d5, .m6, .M6, .M7], description: "Lydian Augmented")
   /// Neopolitan major scale.
-  case neopolitanMajor
+  public static let neopolitanMajor = ScaleType(intervals: [.P1, .m2, .m3, .P4, .P5, .M6, .M7], description: "Neopolitan Major")
   /// Neopolitan minor scale.
-  case neopolitanMinor
+  public static let neopolitanMinor = ScaleType(intervals: [.P1, .m2, .m3, .P4, .P5, .m6, .m7], description: "Neopolitan Minor")
   /// Pelog scale.
-  case pelog
+  public static let pelog = ScaleType(intervals: [.P1, .m2, .m3, .d5, .m7, .M7], description: "Pelog")
   /// Prometheus scale.
-  case prometheus
+  public static let prometheus = ScaleType(intervals: [.P1, .M2, .M3, .d5, .M6, .m7], description: "Prometheus")
   /// Prometheus neopolitan scale.
-  case prometheusNeopolitan
+  public static let prometheusNeopolitan = ScaleType(intervals: [.P1, .m2, .M3, .d5, .M6, .m7], description: "Prometheus Neopolitan")
   /// Six tone symmetrical scale.
-  case sixToneSymmetrical
+  public static let sixToneSymmetrical = ScaleType(intervals: [.P1, .m2, .M3, .P4, .m6, .M6], description: "Six Tone Symmetrical")
   /// Super locrian scale.
-  case superLocrian
+  public static let superLocrian = ScaleType(intervals: [.P1, .m2, .m3, .M3, .d5, .m6, .m7], description: "Super Locrian")
   /// Lydian minor scale.
-  case lydianMinor
+  public static let lydianMinor = ScaleType(intervals: [.P1, .M2, .M3, .d5, .P5, .m6, .m7], description: "Lydian Minor")
   /// Lydian diminished scale.
-  case lydianDiminished
+  public static let lydianDiminished = ScaleType(intervals: [.P1, .M2, .m3, .d5, .P5, .m6, .m7], description: "Lydian Diminished")
   /// Nine tone scale.
-  case nineToneScale
+  public static let nineToneScale = ScaleType(intervals: [.P1, .M2, .m3, .M3, .d5, .P5, .m6, .M6, .M7], description: "Nine Tone Scale")
   /// Auxiliary diminished scale.
-  case auxiliaryDiminished
+  public static let auxiliaryDiminished = ScaleType(intervals: [.P1, .M2, .m3, .P4, .d5, .m6, .M6, .M7], description: "Auxiliary Diminished")
   /// Auxiliary augmaneted scale.
-  case auxiliaryAugmented
+  public static let auxiliaryAugmented = ScaleType(intervals: [.P1, .M2, .M3, .d5, .m6, .m7], description: "Auxiliary Augmented")
   /// Auxiliary diminished blues scale.
-  case auxiliaryDimBlues
+  public static let auxiliaryDimBlues = ScaleType(intervals: [.P1, .m2, .m3, .M3, .d5, .P5, .M6, .m7], description: "Auxiliary Diminished Blues")
   /// Major locrian scale.
-  case majorLocrian
+  public static let majorLocrian = ScaleType(intervals: [.P1, .M2, .M3, .P4, .d5, .m6, .m7], description: "Major Locrian")
   /// Overtone scale.
-  case overtone
+  public static let overtone = ScaleType(intervals: [.P1, .M2, .M3, .d5, .P5, .M6, .m7], description: "Overtone")
   /// Diminished whole tone scale.
-  case diminishedWholeTone
+  public static let diminishedWholeTone = ScaleType(intervals: [.P1, .m2, .m3, .M3, .d5, .m6, .m7], description: "Diminished Whole Tone")
   /// Pure minor scale.
-  case pureMinor
+  public static let pureMinor = ScaleType(intervals: [.P1, .M2, .m3, .P4, .P5, .m6, .m7], description: "Pure Minor")
   /// Dominant seventh scale.
-  case dominant7th
-  /// Custom scale with given interval set.
-  case custom(intervals: [Interval], description: String)
+  public static let dominant7th = ScaleType(intervals: [.P1, .M2, .M3, .P4, .P5, .M6, .m7], description: "Dominant 7th")
 
+  /// Intervals of the scale.
+  public let intervals: [Interval]
+  public let description: String
   /// Tries to initilize scale with a matching interval series. If no scale matched with intervals, than initlizes custom scale.
   ///
   /// - Parameters:
   ///   - intervals: Intervals of the chord.
   ///   - description: In case of .custom type scale, you probably need description.
   public init(intervals: [Interval], description: String = "") {
-    if let scale = ScaleType.all.filter({ $0.intervals == intervals }).first {
-      self = scale
-    } else {
-      self = .custom(intervals: intervals, description: description)
-    }
-  }
-
-  /// Intervals of the scale.
-  public var intervals: [Interval] {
-    switch self {
-    case .major: return [.P1, .M2, .M3, .P4, .P5, .M6, .M7]
-    case .minor: return [.P1, .M2, .m3, .P4, .P5, .m6, .m7]
-    case .harmonicMinor: return [.P1, .M2, .m3, .P4, .P5, .m6, .M7]
-    case .dorian: return [.P1, .M2, .m3, .P4, .P5, .M6, .m7]
-    case .phrygian: return [.P1, .m2, .m3, .P4, .P5, .m6, .m7]
-    case .lydian: return [.P1, .M2, .M3, .d5, .P5, .M6, .M7]
-    case .mixolydian: return [.P1, .M2, .M3, .P4, .P5, .M6, .m7]
-    case .locrian: return [.P1, .m2, .m3, .P4, .d5, .m6, .m7]
-    case .melodicMinor: return [.P1, .M2, .m3, .P4, .P5, .M6, .M7]
-    case .pentatonicMajor: return [.P1, .M2, .M3, .P5, .M6]
-    case .pentatonicMinor: return [.P1, .m3, .P4, .P5, .m7]
-    case .pentatonicBlues: return [.P1, .m3, .P4, .d5, .P5, .m7]
-    case .pentatonicNeutral: return [.P1, .M2, .P4, .P5, .m7]
-    case .ionian: return [.P1, .M2, .M3, .P4, .P5, .M6, .M7]
-    case .aeolian: return [.P1, .M2, .m3, .P4, .P5, .m6, .m7]
-    case .dimHalf: return [.P1, .m2, .m3, .M3, .d5, .P5, .M6, .m7]
-    case .dimWhole: return [.P1, .M2, .m3, .P4, .d5, .m6, .M6, .M7]
-    case .whole: return [.P1, .M2, .M3, .d5, .m6, .m7]
-    case .augmented: return [.m3, .M3, .P5, .m6, .M7]
-    case .chromatic: return [.P1, .m2, .M2, .m3, .M3, .P4, .d5, .P5, .m6, .M6, .m7, .M7]
-    case .roumanianMinor: return [.P1, .M2, .m3, .d5, .P5, .M6, .m7]
-    case .spanishGypsy: return [.P1, .m2, .M3, .P4, .P5, .m6, .m7]
-    case .blues: return [.P1, .m3, .P4, .d5, .P5, .m7]
-    case .diatonic: return [.P1, .M2, .M3, .P5, .M6]
-    case .doubleHarmonic: return [.P1, .m2, .M3, .P4, .P5, .m6, .M7]
-    case .eightToneSpanish: return [.P1, .m2, .m3, .M3, .P4, .d5, .m6, .m7]
-    case .enigmatic: return [.P1, .m2, .M3, .d5, .m6, .m7, .M7]
-    case .leadingWholeTone: return [.P1, .M2, .M3, .d5, .m6, .M6, .m7]
-    case .lydianAugmented: return [.P1, .M2, .M3, .d5, .m6, .M6, .M7]
-    case .neopolitanMajor: return [.P1, .m2, .m3, .P4, .P5, .M6, .M7]
-    case .neopolitanMinor: return [.P1, .m2, .m3, .P4, .P5, .m6, .m7]
-    case .pelog: return [.P1, .m2, .m3, .d5, .m7, .M7]
-    case .prometheus: return [.P1, .M2, .M3, .d5, .M6, .m7]
-    case .prometheusNeopolitan: return [.P1, .m2, .M3, .d5, .M6, .m7]
-    case .sixToneSymmetrical: return [.P1, .m2, .M3, .P4, .m6, .M6]
-    case .superLocrian: return [.P1, .m2, .m3, .M3, .d5, .m6, .m7]
-    case .lydianMinor: return [.P1, .M2, .M3, .d5, .P5, .m6, .m7]
-    case .lydianDiminished: return [.P1, .M2, .m3, .d5, .P5, .m6, .m7]
-    case .nineToneScale: return [.P1, .M2, .m3, .M3, .d5, .P5, .m6, .M6, .M7]
-    case .auxiliaryDiminished: return [.P1, .M2, .m3, .P4, .d5, .m6, .M6, .M7]
-    case .auxiliaryAugmented: return [.P1, .M2, .M3, .d5, .m6, .m7]
-    case .auxiliaryDimBlues: return [.P1, .m2, .m3, .M3, .d5, .P5, .M6, .m7]
-    case .majorLocrian: return [.P1, .M2, .M3, .P4, .d5, .m6, .m7]
-    case .overtone: return [.P1, .M2, .M3, .d5, .P5, .M6, .m7]
-    case .diminishedWholeTone: return [.P1, .m2, .m3, .M3, .d5, .m6, .m7]
-    case .pureMinor: return [.P1, .M2, .m3, .P4, .P5, .m6, .m7]
-    case .dominant7th: return [.P1, .M2, .M3, .P4, .P5, .M6, .m7]
-    case .custom(let intervals, _): return intervals
-    }
+    self.intervals = intervals
+    self.description = description
   }
 
   /// An array of all `ScaleType` values.
@@ -211,7 +145,7 @@ public enum ScaleType: Equatable {
       .whole,
       .augmented,
       .chromatic,
-      .roumanianMinor,
+      .romanianMinor,
       .spanishGypsy,
       .blues,
       .diatonic,
@@ -240,6 +174,18 @@ public enum ScaleType: Equatable {
       .dominant7th,
     ]
   }
+
+  // MARK: Equatable
+
+  /// Checks the equability between two `ScaleType`s by their intervals.
+  ///
+  /// - Parameters:
+  ///   - left: Left handside of the equation.
+  ///   - right: Right handside of the equation.
+  /// - Returns: Returns Bool value of equation of two given scale types.
+  public static func == (left: ScaleType, right: ScaleType) -> Bool {
+    return left.intervals == right.intervals
+  }
 }
 
 extension ScaleType: Codable {
@@ -266,62 +212,6 @@ extension ScaleType: Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(intervals, forKey: .intervals)
-  }
-}
-
-extension ScaleType: CustomStringConvertible {
-  /// Converts `ScaleType` to string with its name.
-  public var description: String {
-    switch self {
-    case .major: return "Major"
-    case .minor: return "Minor"
-    case .harmonicMinor: return "Harmonic Minor"
-    case .melodicMinor: return "Melodic Minor"
-    case .pentatonicMajor: return "Pentatonic Major"
-    case .pentatonicMinor: return "Pentatonic Minor"
-    case .pentatonicBlues: return "Pentatonic Blues"
-    case .pentatonicNeutral: return "Pentatonic Neutral"
-    case .ionian: return "Ionian"
-    case .aeolian: return "Aeolian"
-    case .dorian: return "Dorian"
-    case .mixolydian: return "Mixolydian"
-    case .phrygian: return "Phrygian"
-    case .lydian: return "Lydian"
-    case .locrian: return "Locrian"
-    case .dimHalf: return "Half Diminished"
-    case .dimWhole: return "Whole Diminished"
-    case .whole: return "Whole"
-    case .augmented: return "Augmented"
-    case .chromatic: return "Chromatic"
-    case .roumanianMinor: return "Roumanian Minor"
-    case .spanishGypsy: return "Spanish Gypsy"
-    case .blues: return "Blues"
-    case .diatonic: return "Diatonic"
-    case .doubleHarmonic: return "Double Harmonic"
-    case .eightToneSpanish: return "Eight Tone Spanish"
-    case .enigmatic: return "Enigmatic"
-    case .leadingWholeTone: return "Leading Whole Tone"
-    case .lydianAugmented: return "Lydian Augmented"
-    case .neopolitanMajor: return "Neopolitan Major"
-    case .neopolitanMinor: return "Neopolitan Minor"
-    case .pelog: return "Pelog"
-    case .prometheus: return "Prometheus"
-    case .prometheusNeopolitan: return "Prometheus Neopolitan"
-    case .sixToneSymmetrical: return "Six Tone Symmetrical"
-    case .superLocrian: return "Super Locrian"
-    case .lydianMinor: return "Lydian Minor"
-    case .lydianDiminished: return "Lydian Diminished"
-    case .nineToneScale: return "Nine Tone Scale"
-    case .auxiliaryDiminished: return "Auxiliary Diminished"
-    case .auxiliaryAugmented: return "Auxiliary Augmented"
-    case .auxiliaryDimBlues: return "Auxiliary Diminished Blues"
-    case .majorLocrian: return "Major Locrian"
-    case .overtone: return "Overtone"
-    case .diminishedWholeTone: return "Diminished Whole Tone"
-    case .pureMinor: return "Pure Minor"
-    case .dominant7th: return "Dominant 7th"
-    case let .custom(_, description): return description
-    }
   }
 }
 


### PR DESCRIPTION
…semantic equality between custom created objects and predefined options.

## Rationale

It might be tempting to define these types as `enum` for predefined options due to its succinct syntax. However, the existence of `.custom(value)` options challenges the use of `enum`.

**We design every case in the enum to be unique and mutually exclusive with other cases.** In the current code, multiple representations using more than one case with the same semantic can exist, violating the principle.

For example, `ChordProgression.i_v_vi_iv != ChordProgression.custom([.i, .v, .vi, .iv])` but they are semantically the same. An author can write I-V-VI-IV progressions in both ways and treat them as the same. However when determining equality between I-V-VI-IV representations, we may get either true or false depending if the same representations are being compared. This is undesirable.

With minimum API change I changed the `enum` types to `struct` and make every case a `static let`, so `ChordProgression.i_v_vi_iv == ChordProgression.init([.i, .v, .vi, .iv])`. This also eliminate the separate implementation of `description` and combine the initializer with the declaration (so we don't need patterns like `public var intervals: [Interval] { switch(self} { ... } }`).

This change should be transparent to the outside API except the typo correction of `Romanian Minor`.