### PR TITLE
Fix conversion of string with uppercase note to Pitch

### DIFF
--- a/MusicTheoryTests/MusicTheoryTests.swift
+++ b/MusicTheoryTests/MusicTheoryTests.swift
@@ -96,6 +96,14 @@ extension MusicTheoryTests {
     let p: Pitch = "f#-5"
     XCTAssert(p.key === Key(type: .f, accidental: .sharp))
     XCTAssert(p.octave == -5)
+    
+    let uppercasePitch: Pitch = "A#3"
+    XCTAssert(uppercasePitch.key === Key(type: .a, accidental: .sharp))
+    XCTAssert(uppercasePitch.octave == 3)
+    
+    let uppercasePitch2: Pitch = "F4"
+    XCTAssert(uppercasePitch2.key === Key(type: .f, accidental: .natural))
+    XCTAssert(uppercasePitch2.octave == 4)
   }
 
   func testFrequency() {

--- a/Source/Key.swift
+++ b/Source/Key.swift
@@ -119,7 +119,7 @@ public struct Key: Codable, Equatable, Hashable, ExpressibleByStringLiteral, Cus
     ///
     /// - Parameter value: String representation of type.
     public init(stringLiteral value: KeyType.StringLiteralType) {
-      switch value {
+      switch value.lowercased() {
       case "a": self = .a
       case "b": self = .b
       case "c": self = .c


### PR DESCRIPTION
## Description of the problem:

I was using the Pitch struct to convert an array of note strings into MIDI note values, and saw unexpected values. Here is a simplified version of my code:

```
let noteSequence = ["E4","D4","C#4","B3"]
    
for noteString in noteSequence {
    print("Original Note: \(noteString)")
    let pitch = Pitch(stringLiteral: noteString)
    print("Converted Note: \(pitch.description)")
}
```

## Expected behavior:

The print statements should look like this:

```
Original Note: E4
Converted Note: E4
Original Note: D4
Converted Note: D4
Original Note: C#4
Converted Note: C♯4
Original Note: B3
Converted Note: B3
```

## Actual behavior:

All note names were converted to C, though the sharp accidental and the octave were both converted correctly:

```
Original Note: E4
Converted Note: C4
Original Note: D4
Converted Note: C4
Original Note: C#4
Converted Note: C♯4
Original Note: B3
Converted Note: C3
```

## Identified cause:

The regex in `Pitch`'s `init(stringLiteral:)` does match uppercase notes, but when a string with an uppercase note is used to initalize a `Pitch` struct, the note is always to assigned to a C in the correct octave, as seen above.

The root cause is that the switch statement in `KeyType`'s `init(stringLiteral:)` method has cases for lowercase note letters, but does not have cases for uppercase note letters, so uppercase strings fall through to the default case, which returns `.c`.

## Fix included: 

I added a call to the `lowercased()` method of the string in the switch statement so uppercase letters will be mapped to the lowercase letters, and match the existing cases.

Alternative solutions considered:

**Add seven more individual cases for A...G in switch statement:**

```
 case "A": self = .a
 case "B": self = .b
 case "C": self = .c
 case "D": self = .d
 case "E": self = .e
 case "F": self = .f
 case "G": self = .g
```

This seems too verbose.

**Make this a failable initializer instead of returning `.c` for unrecognized values.**

This would have clear benefits, but also a wide impact to call sites in existing code.


## Testing:

I added two tests for uppercase notes to the end of `testPitches()` method.