### PR TITLE
Fixed bug where no third would be present with ChordTypes with ChordS…

### DIFF
--- a/Source/Chord.swift
+++ b/Source/Chord.swift
@@ -585,7 +585,7 @@ public struct ChordType: ChordDescription {
 
   /// Intervals of parts between root.
   public var intervals: [Interval] {
-    var parts: [ChordPart?] = [sixth == nil ? third : nil, suspended, fifth, sixth, seventh]
+    var parts: [ChordPart?] = [third, suspended, fifth, sixth, seventh]
     parts += extensions?.sorted(by: { $0.type.rawValue < $1.type.rawValue }).map({ $0 as ChordPart? }) ?? []
     return [.P1] + parts.compactMap({ $0?.interval })
   }


### PR DESCRIPTION
…ixthType

This ensures ChordThirdType is preserved even if ChordSixthType is present in ChordType.